### PR TITLE
Checking for NaN value of "double" type has been fixed.

### DIFF
--- a/src/main/java/in/satpathy/financial/XIRR.java
+++ b/src/main/java/in/satpathy/financial/XIRR.java
@@ -75,7 +75,7 @@ public class XIRR {
 		}
 
 		System.out.println( "XIRR Result - " + result ) ;
-		return (result != Double.NaN) ? (result - 1) : result ;
+		return (Double.isNaN(result)) ? (result - 1) : result ;
 	}
 
 }   /*  End of the XIRR class. */


### PR DESCRIPTION
A condition 
    doubleVal == Double.NaN 
will return FALSE every time.

There is an explanation at the Stackoverflow: http://stackoverflow.com/a/8819776
